### PR TITLE
Fix use of abs() with string on PHP8.0

### DIFF
--- a/runtime/lib/parser/yaml/sfYamlParser.php
+++ b/runtime/lib/parser/yaml/sfYamlParser.php
@@ -325,7 +325,7 @@ class sfYamlParser
     if (preg_match('/^(?P<separator>\||>)(?P<modifiers>\+|\-|\d+|\+\d+|\-\d+|\d+\+|\d+\-)?(?P<comments> +#.*)?$/', $value, $matches)) {
       $modifiers = isset($matches['modifiers']) ? $matches['modifiers'] : '';
 
-      return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), intval(abs($modifiers)));
+      return $this->parseFoldedScalar($matches['separator'], preg_replace('#\d+#', '', $modifiers), abs((int)$modifiers));
     } else {
       return sfYamlInline::load($value);
     }


### PR DESCRIPTION
Can happen when using Yaml's multiline syntax.